### PR TITLE
Add a link to pyModeS on github

### DIFF
--- a/_templates/related.html
+++ b/_templates/related.html
@@ -1,0 +1,6 @@
+  <br/>
+  <h3>{{ _('Related') }}</h3>
+  <ul class="this-page-menu">
+    <li><a href="https://github.com/junzis/pyModeS"
+           rel="nofollow">{{ _('pyModeS on GitHub') }}</a></li>
+  </ul>

--- a/conf.py
+++ b/conf.py
@@ -79,6 +79,7 @@ html_sidebars = {
         'sourcelink.html',
         'searchbox.html',
         # 'donate.html',
+        'related.html',
     ]
 }
 


### PR DESCRIPTION
At this moment there are links to the pyModeS library sources only in index.rst (an README.rst), ehs.rst and adsb/airborne-position.rst but I think that you could give it more visibility by adding alink somewhere in the sidebar.
Feel free to find a better wording than what I used:

> Related
> pyModeS on GitHub

thanks,
Daniele