### PR TITLE
Include the readme in the index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,10 +8,10 @@ The book about decoding Mode-S and ADS-B data
 Access the online book at: `mode-s.org <http://mode-s.org>`_
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Begun with a frustration on the lack of technical public information on ADS-B and Mode-S in the year 2015, I created an live online document to recorded my understanding of ADS-B data. Previously, this was known as `"ADS-B Decoding Guide" <http://adsb-decode-guide.readthedocs.org/>`_ project. Together with the tutorial, we also developed its related Python library, the `pyModeS <https://github.com/junzis/pyModeS>`_. With time, I received many feedbacks, compliments, and contributions from open-source community users.
+Begun with a frustration on the lack of technical public information on ADS-B and Mode-S in the year 2015, I created a live online document to record my understanding of ADS-B data. Previously, this was known as `"ADS-B Decoding Guide" <http://adsb-decode-guide.readthedocs.org/>`_ project. Together with the tutorial, we also developed its related Python library, the `pyModeS <https://github.com/junzis/pyModeS>`_. With time, I received many feedbacks, compliments, and contributions from open-source community users.
 
-From beginning of 2017, the interests of tapping into Enhanced Mode-S (EHS) data brought us a whole new chapter of Mode-S inference and decoding into the pyModeS. This also enriches the "ADS-B" guide. With the advance in this area, I am planning to compile a more comprehensive online book to cover both ADS-B and Mode-S decoding and related topic.
+Since the beginning of 2017, the interests of tapping into Enhanced Mode-S (EHS) data brought us a whole new chapter of Mode-S inference and decoding into the pyModeS. This also enriches the "ADS-B" guide. With the advance in this area, I am planning to compile a more comprehensive online book to cover both ADS-B and Mode-S decoding and related topic.
 
-That's the starting of this new repository. I am also starting host the online book on my own server to allow more flexibility of editing and publishing. You can read the most up-to-date book on `mode-s.org <http://mode-s.org>`_.
+That's the starting of this new repository. I am also starting to host the online book on my own server to allow more flexibility of editing and publishing. You can read the most up-to-date book on `mode-s.org <http://mode-s.org>`_.
 
-Oh, it is still GNU GPL. It was great to see the pull request from different contributors previously. I am looking forward to seeing more comments and pulls from the community. Enjoy!
+Oh, it is still GNU GPL. It was great to see the pull requests from different contributors previously. I am looking forward to seeing more comments and pulls from the community. Enjoy!

--- a/index.rst
+++ b/index.rst
@@ -8,13 +8,8 @@ The book about decoding Mode-S and ADS-B data
 Preface
 =======
 
-Begun with a frustration on the lack of technical public information on ADS-B and Mode-S in the year 2015, I created a live online document to record my understanding of ADS-B data. Previously, this was known as `"ADS-B Decoding Guide" <http://adsb-decode-guide.readthedocs.org/>`_ project. Together with the tutorial, we also developed its related Python library, the `pyModeS <https://github.com/junzis/pyModeS>`_. With time, I received many feedbacks, compliments, and contributions from open-source community users.
-
-Since the beginning of 2017, the interests of tapping into Enhanced Mode-S (EHS) data brought us a whole new chapter of Mode-S inference and decoding into the pyModeS. This also enriches the "ADS-B" guide. With the advance in this area, I am planning to compile a more comprehensive online book to cover both ADS-B and Mode-S decoding and related topic.
-
-That's the starting of this new repository. I am also starting to host the online book on my own server to allow more flexibility of editing and publishing. You can read the most up-to-date book on `mode-s.org <http://mode-s.org>`_.
-
-Oh, it is still GNU GPL. It was great to see the pull requests from different contributors previously. I am looking forward to seeing more comments and pulls from the community. Enjoy!
+.. include:: README.rst
+   :start-line: 10
 
 Table of contents
 -----------------


### PR DESCRIPTION
Hello,

you may want to apply these two commits:
* the first patch fixes some typos in the README that I missed from a previous PR and makes the text identical to that in index.rst
* the second patch removes the duplicated text from the index and includes the text from the readme skipping the lines that contain the title and the link to the web site that is shown later

I checked that the index.html file generated before and after this patch has the same contents.

Including the README.rst also fixes this warning shown during the build:
> .../the-1090mhz-riddle/README.rst: WARNING: document isn't included in any toctree

thank you,
Daniele
