### PR TITLE
Typo in example

### DIFF
--- a/adsb/identification.tex
+++ b/adsb/identification.tex
@@ -40,7 +40,7 @@ The structure of the message is as follows:
      DF... CA.  ICAO..  DATA..................  PI....
 HEX: 8   D      4840D6  2   0     2CC371C32CE0  576098
 BIN: 10001 101  ******  00100 000 ************  ******
-DEC: 17    4            4     0
+DEC: 17    5            4     0
                         TC    *
 \end{verbatim}
 


### PR DESCRIPTION
Just a minor typo: the DEC representation of the CA value in the example should be 5 (binary is 0b101).