### PR TITLE
Fix typo in type code

### DIFF
--- a/adsb/version.tex
+++ b/adsb/version.tex
@@ -10,7 +10,7 @@ From \texttt{Version\ 0} to \texttt{Version\ 1}:
 
 \begin{itemize}
 \item
-  Added Type Code 28, 19, and 31 messages
+  Added Type Code 28, 29, and 31 messages
 
   \begin{itemize}
     \item


### PR DESCRIPTION
Type code 29 was incorrectly referenced as type code 19.