### PR TITLE
table references not working (and shown in caption)

### DIFF
--- a/adsb/introduction.tex
+++ b/adsb/introduction.tex
@@ -16,8 +16,6 @@ In following Table \ref{tb:adsb-structure}, the key information of a ADS-B messa
 
 \begin{table}[!ht]
 \centering
-\caption{Structure of ADS-B messages}
-\label{tb:adsb-structure}
 \begin{tabular}{@{}llll@{}}
 \toprule
 nBits & Bits & Abbr. & Name \\ \midrule
@@ -28,6 +26,8 @@ nBits & Bits & Abbr. & Name \\ \midrule
  & {[}33 - 37{]} & {[}TC{]} & Type code \\
 24 & 89 - 112 & PI & Parity/Interrogator ID \\ \bottomrule
 \end{tabular}
+\caption{Structure of ADS-B messages}
+\label{tb:adsb-structure}
 \end{table}
 
 It is worth noting that the ADS-B Extended Squitter sent from a Mode S transponder use Downlink Format 17 (\texttt{DF=17}). Non-Transponder-Based ADS-B Transmitting Subsystems and TIS-B Transmitting equipment use Downlink Format 18 (\texttt{DF=18}). By using \texttt{DF=18} instead of \texttt{DF=17}, an ADS-B/TIS-B Receiving Subsystem will know that the message comes from equipment that cannot be interrogated.
@@ -71,8 +71,6 @@ In following Table \ref{tb:adsb-tc}, the relationships between each \texttt{Type
 
 \begin{table}[!ht]
 \centering
-\caption{ADS-B Type Code and content}
-\label{tb:adsb-tc}
 \begin{tabular}{@{}ll@{}}
 \toprule
 Type Code & Content                              \\ \midrule
@@ -86,6 +84,8 @@ Type Code & Content                              \\ \midrule
 29        & Target state and status information  \\
 31        & Aircraft operation status            \\ \bottomrule
 \end{tabular}
+\caption{ADS-B Type Code and content}
+\label{tb:adsb-tc}
 \end{table}
 
 \subsection{ADS-B Checksum}\label{ads-b-checksum}


### PR DESCRIPTION
I noticed that Table captions contained their relevant labels and reference are not working.
From my past LaTeX examples I have seen the changes I proposed working, but I could not prove the case in this instance...