### PR TITLE
use "Operational status" not "Operation status"

### DIFF
--- a/adsb/operation-status.tex
+++ b/adsb/operation-status.tex
@@ -1,12 +1,12 @@
-\section{Aircraft Operation Status}\label{aircraft-operation-status}
+\section{Aircraft Operational Status}\label{aircraft-operation-status}
 
-Operation status message is introduced since the \texttt{Version\ 1} of ADS-B. And there are also slight differences in the structure of Aircraft Operation Messages between Version 1 and 2.
+Operational status message is introduced since the \texttt{Version\ 1} of ADS-B. And there are also slight differences in the structure of Aircraft Operation Messages between Version 1 and 2.
 
 \begin{quote}
 To understand about these versions, first take a look at the \href{version.html}{ADS-B version chapter}.
 \end{quote}
 
-The operation status is transmitted with \texttt{Type\ Code} 31 (\texttt{TC=31}). The structure of the message (in \texttt{Version\ 1}) is laid out as follows:
+The operational status is transmitted with \texttt{Type\ Code} 31 (\texttt{TC=31}). The structure of the message (in \texttt{Version\ 1}) is laid out as follows:
 
 \begin{verbatim}
 +----------------------------------------+------+------+------+


### PR DESCRIPTION
The specs DO-260B [1] call it "Operational status"
(To be frank there are 2 mentions of "Operation status" out of 10s -100s of "Operational status")

HTH

[1] RTCA "Minimum Operational Performance Standards for 1090 MHz Extended Squitter Automatic Dependent Surveillance - Broadcast (ADS-B) and Traffic Information Services - Broadcast (TIS-B)", (Corrigendum 1, Appendix W, integrated and highlighted), Dec 13, 2011